### PR TITLE
Drush 5.8 & corrected symlinks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,10 +48,10 @@ Vagrant::Config.run do |config|
         :hosts => {
           :localhost_aliases => ["dev-site.vm"]
         },
-			  :drush => {
-				  :install_method => 'pear',
-				  :version => '5.8.0',
-			  }
+        :drush => {
+          :install_method => 'pear',
+          :version => '5.8.0',
+        }
       })
   end
 end

--- a/cookbooks/drupal-cookbooks/drush/recipes/default.rb
+++ b/cookbooks/drupal-cookbooks/drush/recipes/default.rb
@@ -19,8 +19,8 @@ case node[:platform]
 when "debian", "ubuntu"
   bash "install-drush" do
     code <<-EOH
-(cd /tmp; wget http://ftp.drupal.org/files/projects/drush-7.x-4.5.tar.gz)
-(cd /tmp; tar zxvf drush-7.x-4.5.tar.gz)
+(cd /tmp; wget http://ftp.drupal.org/files/projects/drush-7.x-5.8.tar.gz)
+(cd /tmp; tar zxvf drush-7.x-5.8.tar.gz)
 (cd /tmp; mv drush /usr/share/)
 (ln -s /usr/share/drush/drush /usr/bin/drush)
 (pear install Console_Table)

--- a/cookbooks/drupal-cookbooks/drush/recipes/head.rb
+++ b/cookbooks/drupal-cookbooks/drush/recipes/head.rb
@@ -19,7 +19,7 @@ case node[:platform]
 when "debian", "ubuntu"
   git "/usr/share/drush" do
     repository "git://git.drupal.org/project/drush.git"
-    reference "master"
+    reference "8.x-6.x"
     action :sync
   end
   


### PR DESCRIPTION
Exactly what the title says, now when `vagrant up` is finished with it's business, you can ssh into the vm and run `drush` without error. The issue was due to the master drush repository specified in the cookbook not being used anymore. 
