### PR TITLE
Update the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .vagrant
 public/
+/public
 private/

--- a/README.markdown
+++ b/README.markdown
@@ -6,9 +6,11 @@ VirtualBox Vagrant Chef Drupal install
 1. Download and Install [VirtualBox](http://www.virtualbox.org/) (ensure you are on the latest version 4.0.8+)
 2. Install [vagrant](http://vagrantup.com/v1/docs/getting-started/index.html)
 3. Download or Clone this project go to the folder and launch the box:
-    `cd [vagrant project directory];
-    mkdir public;
-    vagrant up`
+```bash
+cd [vagrant project directory]
+mkdir public
+vagrant up
+```
 4. Add this line to your /etc/hosts (or windows equivalent):
     `10.0.0.10        dev-site.vm`
 5. Alternately, use homebrew on your macbook air to install dnsmasq, and add the following line to your dnsmasq.conf file:
@@ -16,7 +18,7 @@ VirtualBox Vagrant Chef Drupal install
 6. Drink a big kombucha while you listen to a Diamond Rings EP on vinyl, because clearly you're a giant hipster.
 
 
-That's it, files in "/vagrant/public" are served here: [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
+That's it, files in `/vagrant/public` are served here: [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
 
 To connect to the console of your instance:
     `vagrant ssh` 

--- a/README.markdown
+++ b/README.markdown
@@ -9,13 +9,13 @@ VirtualBox Vagrant Chef Drupal install
     `cd [vagrant project directory];
     vagrant up`
 4. Add this line to your /etc/hosts (or windows equivalent):
-    `10.0.0.10        dev-site.local`
+    `10.0.0.10        dev-site.vm`
 5. Alternately, use homebrew on your macbook air to install dnsmasq, and add the following line to your dnsmasq.conf file:
     `address=/.vm/10.0.0.10`
 6. Drink a big kombucha while you listen to a Diamond Rings EP on vinyl, because clearly you're a giant hipster.
 
 
-That's it, files in "public" are served here : [http://dev-site.local/](http://dev-site.local/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
+That's it, files in "public" are served here : [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
 
 To connect to the console of you instance:
     `vagrant ssh` 
@@ -29,9 +29,9 @@ This project is based on the [Vagrant Project](http://drupal.org/project/vagrant
 
 --------
 
-You can add `XDEBUG_PROFILE` to your GET parameter to generate an xdebug profile, e.g. [http://dev-site.vbox.local/?XDEBUG_PROFILE](http://dev-site.vbox.local/?XDEBUG_PROFILE)
+You can add `XDEBUG_PROFILE` to your GET parameter to generate an xdebug profile, e.g. [http://dev-site.vm/?XDEBUG_PROFILE](http://dev-site.vm/?XDEBUG_PROFILE)
 
-You can then investigate at [http://dev-site.local/webgrind/](http://dev-site.local/webgrind/)
+You can then investigate at [http://dev-site.vm/webgrind/](http://dev-site.vm/webgrind/)
 
 
 ## Other projects of interest

--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,7 @@ VirtualBox Vagrant Chef Drupal install
 2. Install [vagrant](http://vagrantup.com/v1/docs/getting-started/index.html)
 3. Download or Clone this project go to the folder and launch the box:
     `cd [vagrant project directory];
+    mkdir public;
     vagrant up`
 4. Add this line to your /etc/hosts (or windows equivalent):
     `10.0.0.10        dev-site.vm`
@@ -15,9 +16,9 @@ VirtualBox Vagrant Chef Drupal install
 6. Drink a big kombucha while you listen to a Diamond Rings EP on vinyl, because clearly you're a giant hipster.
 
 
-That's it, files in "public" are served here : [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
+That's it, files in "/vagrant/public" are served here: [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
 
-To connect to the console of you instance:
+To connect to the console of your instance:
     `vagrant ssh` 
 
 # Why

--- a/README.markdown
+++ b/README.markdown
@@ -6,9 +6,13 @@ VirtualBox Vagrant Chef Drupal install
 1. Download and Install [VirtualBox](http://www.virtualbox.org/) (ensure you are on the latest version 4.0.8+)
 2. Install [vagrant](http://vagrantup.com/v1/docs/getting-started/index.html)
 3. Download or Clone this project go to the folder and launch the box:
-    `cd [vagrant project directory];
-    mkdir public;
-    vagrant up`
+
+```
+cd [vagrant project directory]
+mkdir public
+vagrant up
+```
+
 4. Add this line to your /etc/hosts (or windows equivalent):
     `10.0.0.10        dev-site.vm`
 5. Alternately, use homebrew on your macbook air to install dnsmasq, and add the following line to your dnsmasq.conf file:
@@ -16,7 +20,7 @@ VirtualBox Vagrant Chef Drupal install
 6. Drink a big kombucha while you listen to a Diamond Rings EP on vinyl, because clearly you're a giant hipster.
 
 
-That's it, files in "/vagrant/public" are served here: [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
+That's it, files in `/vagrant/public` are served here: [http://dev-site.vm/](http://dev-site.vm/), and if you have a new MySQL database and drop a copy of Drupal into the public directory, you'll be ready to go.
 
 To connect to the console of your instance:
     `vagrant ssh` 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,9 @@
-Vagrant::Config.run do |config|
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. For a detailed explanation
   # and listing of configuration options, please view the documentation
   # online.
@@ -6,19 +11,16 @@ Vagrant::Config.run do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "precise32"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
-  # config.vm.boot_mode = :gui
 
-  # Network setting for Vagrant >= 0.90
-  config.vm.network :hostonly, "10.0.0.10"
-  config.vm.forward_port(80, 80)
-  config.vm.forward_port(3306, 3306)
+  config.vm.network "private_network", ip: "10.0.0.10"
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 3306, host: 3030
 
   # Try to use NFS only on platforms other than Windows
   nfs = !Kernel.is_windows?
-  config.vm.synced_folder(".", "/vagrant", :nfs => nfs)
+  config.vm.synced_folder ".", "/vagrant", type: "nfs"
 
   config.vm.provider :virtualbox do |vb|
-    # Memory setting for Vagrant >= 0.90
     vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
@@ -27,12 +29,12 @@ Vagrant::Config.run do |config|
     # This path will be expanded relative to the project directory
     chef.cookbooks_path = ["cookbooks/site-cookbooks", "cookbooks/drupal-cookbooks"]
 
-    chef.add_recipe("vim")
+    chef.add_recipe "vim" 
 
     chef.roles_path = "roles"
 
     # This role represents our default Drupal development stack.
-    chef.add_role("drupal_lamp_dev")
+    chef.add_role "drupal_lamp_dev" 
 
     chef.json.merge!({
         :www_root => '/vagrant/public',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,17 +8,6 @@ Vagrant::Config.run do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
   # config.vm.boot_mode = :gui
 
-  # Memory setting for Vagrant < 0.90
-  # config.vm.customize do |vm|
-  #   vm.memory_size = 1024
-  # end
-
-  # Memory setting for Vagrant >= 0.90
-  config.vm.customize ["modifyvm", :id, "--memory", "1024"]
-
-  # Network setting for Vagrant < 0.90
-  # config.vm.network("10.0.0.10")
-
   # Network setting for Vagrant >= 0.90
   config.vm.network :hostonly, "10.0.0.10"
   config.vm.forward_port(80, 80)
@@ -26,18 +15,22 @@ Vagrant::Config.run do |config|
 
   # Try to use NFS only on platforms other than Windows
   nfs = !Kernel.is_windows?
-  config.vm.share_folder("v-root", "/vagrant", ".", :nfs => nfs)
+  config.vm.synced_folder(".", "/vagrant", :nfs => nfs)
 
-  config.vm.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  config.vm.provider :virtualbox do |vb|
+    # Memory setting for Vagrant >= 0.90
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
 
   config.vm.provision :chef_solo do |chef|
     # This path will be expanded relative to the project directory
     chef.cookbooks_path = ["cookbooks/site-cookbooks", "cookbooks/drupal-cookbooks"]
 
     chef.add_recipe("vim")
-    
+
     chef.roles_path = "roles"
-   
+
     # This role represents our default Drupal development stack.
     chef.add_role("drupal_lamp_dev")
 


### PR DESCRIPTION
The readme had me confused for a little bit. I couldn't figure out why the site wasn't being served.

I finally realized it was because I had dev-site.local in /etc/hosts, but Vagrant was really wanting to serve stuff on dev-site.vm since this is what's in the Vagrantfile.

The readme now says to add dev-site.vm to your /etc/hosts. I also included making the "public" directory as part of step 3.
